### PR TITLE
fix(auth): sanitize login user

### DIFF
--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -1,11 +1,11 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Controller, Post, Request, UseGuards } from '@nestjs/common';
 
 import { LocalAuthGuard } from '#/domain/guards/local-auth.guard';
 
 import { AuthRequestDTO } from './dto/request.dto';
 import { AuthResponseDTO } from './dto/response.dto';
 import { AuthService } from './auth.service';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { responseSchema } from '#/shared/utils/response';
 
 @ApiTags('Auth')
@@ -18,6 +18,7 @@ export class AuthController {
   @ApiOperation({
     summary: 'Auth to acess api',
   })
+  @ApiBody({ type: AuthRequestDTO })
   @ApiResponse({
     schema: responseSchema('obj', AuthResponseDTO),
     status: 200,
@@ -25,7 +26,7 @@ export class AuthController {
   @ApiResponse({
     schema: responseSchema('error'),
   })
-  async login(@Body() params: AuthRequestDTO): Promise<AuthResponseDTO> {
-    return this.authService.login(params);
+  async login(@Request() req): Promise<AuthResponseDTO> {
+    return this.authService.login(req.user);
   }
 }

--- a/src/domain/auth/auth.service.spec.ts
+++ b/src/domain/auth/auth.service.spec.ts
@@ -1,0 +1,18 @@
+import { JwtService } from '@nestjs/jwt';
+
+jest.mock('./users/users.service', () => ({
+  UsersService: jest.fn(),
+}));
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  it('should return user data without password', async () => {
+    const usersService = {
+      findOne: jest.fn().mockResolvedValue({ id: 1, username: 'john', password: 'secret' }),
+    } as any;
+    const service = new AuthService(usersService, new JwtService({ secret: 'test' }));
+    const result = await service.validateUser({ username: 'john', password: 'secret' });
+    expect(result).toEqual({ id: 1, username: 'john' });
+  });
+});

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -10,7 +10,7 @@ export class AuthService {
   async validateUser(params: AuthRequestDTO): Promise<any> {
     const user = await this.usersService.findOne(params);
     if (user && user.password === params.password) {
-      const { password, ...result } = params;
+      const { password, ...result } = user;
       return result;
     }
     return null;


### PR DESCRIPTION
## Summary
- ensure AuthService strips password from fetched user
- use authenticated request user when issuing token
- add unit test for AuthService.validateUser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964140633c832e9e09a17c270330e1